### PR TITLE
修正build_headers方法中referer的设置

### DIFF
--- a/ENScan.py
+++ b/ENScan.py
@@ -120,7 +120,7 @@ class EIScan(object):
             'Accept-Language': 'zh-Hans-CN, zh-Hans; q=0.5',
             'Connection': 'Keep-Alive',
             'Cookie': self.cookie,
-            'Referer': "https://aifanfan.baidu.com/",
+            'Referer': referer,
             'User-Agent': ua
         }
         return headers


### PR DESCRIPTION
原header中Referer变量是写死的，将其赋值为referer变量。
